### PR TITLE
Add the missing message status

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -12,7 +12,8 @@ class Message < ApplicationRecord
     initiated: 'initiated',
     sent: 'sent',
     read: 'read',
-    failed: 'failed'
+    failed: 'failed',
+    delivered: 'delivered'
   }
 
   enum sentiment: {

--- a/lib/tasks/generate_message_statistics.rake
+++ b/lib/tasks/generate_message_statistics.rake
@@ -8,11 +8,10 @@ namespace :generate_message_statistics do
       next unless payload.present?
 
       message_entry = Message.find_or_create_by(message_id: payload['messageId'])
-      message_status = payload['msgStream']&.underscore
-      message_type = :outbound if message_status.eql?('outbound')
+      message_type = :outbound if payload['msgStream']&.underscore.eql?('outbound')
       message_entry.update(from: payload['sourceAddress'],
                            to: payload['recipientAddress'],
-                           status: message_status,
+                           status: payload['msgStatus']&.underscore,
                            text: payload.dig('messageParameters', 'text',
                                              'body').presence || message_entry.text,
                            session_id: payload['sessionId'],


### PR DESCRIPTION
## What?
- `Delivered` status was missing in the status enum.
- Fix the rake task to create the messages.