### PR TITLE
Card layout for "Meet the team" improvement

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -146,12 +146,11 @@ body {
 .meet-team {
   .card-array {
     width: 100%;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 2rem;
 
     .card {
-      margin: 0px 50px;
       max-width: 230px;
       border: 1px solid #cbcbcb;
 


### PR DESCRIPTION
## What?
Card layout for "Meet the team" section improvement

## Why?
It is overflowing and the spacing is not proper.

## How?
Changed from `flex` to `grid`.