### PR TITLE
Fix link chatbot with message

### DIFF
--- a/app/models/webhook_event.rb
+++ b/app/models/webhook_event.rb
@@ -7,6 +7,7 @@ class WebhookEvent < ApplicationRecord
 
   def update_message_entry
     message_entry = Message.find_or_create_by(message_id: payload['messageId'])
+
     whatsapp_business_number = case payload['msgStream']
                                when 'OUTBOUND'
                                  country_code = payload['sourceCountry'].split('+').last
@@ -16,13 +17,14 @@ class WebhookEvent < ApplicationRecord
                                  payload['recipientAddress'].split(country_code).last
                                end
     chatbot_id = Chatbot.find_by(phone_number: whatsapp_business_number).try(:id)
+
     message_entry.update(from: payload['sourceAddress'],
-                                    to: payload['recipientAddress'],
-                                    status: payload['msgStatus'].underscore,
-                                    text: payload.dig('messageParameters', 'text',
-                                                      'body').presence || message_entry.text,
-                                    session_id: payload['sessionId'],
-                                    message_type: payload['msgStream'].underscore,
-                                    chatbot_id: chatbot_id)
+                         to: payload['recipientAddress'],
+                         status: payload['msgStatus'].underscore,
+                         text: payload.dig('messageParameters', 'text', 'body').presence || message_entry.text,
+                         session_id: payload['sessionId'],
+                         message_type: payload['msgStream'].underscore,
+                         chatbot_id: chatbot_id
+                        )
   end
 end

--- a/app/models/webhook_event.rb
+++ b/app/models/webhook_event.rb
@@ -7,12 +7,22 @@ class WebhookEvent < ApplicationRecord
 
   def update_message_entry
     message_entry = Message.find_or_create_by(message_id: payload['messageId'])
+    whatsapp_business_number = case payload['msgStream']
+                               when 'OUTBOUND'
+                                 country_code = payload['sourceCountry'].split('+').last
+                                 payload['sourceAddress'].split(country_code).last
+                               when 'INBOUND'
+                                 country_code = payload['recipientCountry'].split('+').last
+                                 payload['recipientAddress'].split(country_code).last
+                               end
+    chatbot_id = Chatbot.find_by(phone_number: whatsapp_business_number).try(:id)
     message_entry.update(from: payload['sourceAddress'],
                                     to: payload['recipientAddress'],
                                     status: payload['msgStatus'].underscore,
                                     text: payload.dig('messageParameters', 'text',
                                                       'body').presence || message_entry.text,
                                     session_id: payload['sessionId'],
-                                    message_type: payload['msgStream'].underscore)
+                                    message_type: payload['msgStream'].underscore,
+                                    chatbot_id: chatbot_id)
   end
 end


### PR DESCRIPTION
## What?
Find and link the chatbot with the Message object in the webhook event creation callback.

## Why?
For outbound messages mainly the chatbot is not getting linked with the message object due to which the stats are not getting pulled.

## How?
We find the chatbot based on the source phone number for outbound messages and the receiver phone number for inbound messages and associate it with the message object.