### PR TITLE
Round off inbound & outbound percentages

### DIFF
--- a/app/views/chatbot/analytics.html.slim
+++ b/app/views/chatbot/analytics.html.slim
@@ -14,10 +14,10 @@
         .total = total_message
         .inbound-percentage.my-3
           = image_tag 'inbound.svg'
-          = "#{inbound_percent.to_i}% Inbound"
+          = "#{inbound_percent.round}% Inbound"
         .outbound-percentage
           = image_tag 'outbound.svg'
-          = "#{outbound_percent.to_i}% Outbound"
+          = "#{outbound_percent.round}% Outbound"
     .report-statistic-box
       .box-header Inbound
       .box-content


### PR DESCRIPTION
## What?
Round off inbound & outbound percentages for the message analytics.

## Why?
Since we were only taking integers earlier the sum total was not making 100%.

## Screenshots/Recording (optional)
<img width="1129" alt="image" src="https://user-images.githubusercontent.com/20839528/205685610-488223ec-eaf6-4dbe-be3f-65fbe933b341.png">
