### PR TITLE
Ability to build chatbot

### DIFF
--- a/app/assets/stylesheets/cm_admin/tags.css.scss
+++ b/app/assets/stylesheets/cm_admin/tags.css.scss
@@ -1,0 +1,10 @@
+.status-tag {
+  &.yellow-tag {
+    color: #FFC845;
+    background: #FFF8E9;
+  }
+  &.red-tag {
+    color: #F83636;
+    background: #FEEFEF;
+  }
+}

--- a/app/models/chatbot.rb
+++ b/app/models/chatbot.rb
@@ -9,6 +9,13 @@ class Chatbot < ApplicationRecord
   has_many :intents, dependent: :delete_all
   has_many :chatbot_sessions, dependent: :destroy
 
+  enum status: {
+    not_built: 'not_built',
+    building: 'building',
+    built: 'built',
+    failed: 'failed'
+  }
+
   validates_format_of :name, with: /\A([a-zA-Z0-9_-]{1,100})\z/, message: 'can have maximum 100 characters. No space is allowed. Valid characters: A–Z, a–z, 0–9, -, _'
   validates_format_of :description, with: /\A(.{,200})\z/, message: 'can have maximum 200 characters.'
   validates_format_of :phone_number, with: /\A([0-9]{10})\z/, message: 'should be of 10 digits.'

--- a/app/models/concerns/aws_lex/chatbot.rb
+++ b/app/models/concerns/aws_lex/chatbot.rb
@@ -31,4 +31,9 @@ module AwsLex::Chatbot
   def delete_bot
     LexModelsV2::Chatbot.new(self).delete_bot
   end
+
+  # Build chatbot and update the status using waiter.
+  def build
+    LexModelsV2::Chatbot.new(self).build
+  end
 end

--- a/app/models/concerns/cm_admin/chatbot.rb
+++ b/app/models/concerns/cm_admin/chatbot.rb
@@ -1,6 +1,8 @@
 module CmAdmin::Chatbot
   extend ActiveSupport::Concern
   included do
+    STATUS_TAG_COLOR = { built: 'success', building: 'yellow-tag', failed: 'red-tag' }
+
     cm_admin do
       actions only: []
       cm_index do
@@ -12,6 +14,7 @@ module CmAdmin::Chatbot
         column :name
         column :description
         column :phone_number, header: 'WhatsApp business number'
+        column :status, field_type: :tag, tag_class: STATUS_TAG_COLOR
       end
 
       cm_show page_title: :name, page_description: 'Chatbot Details' do
@@ -20,6 +23,7 @@ module CmAdmin::Chatbot
             field :name
             field :description
             field :phone_number, label: 'WhatsApp business number'
+            field :status, field_type: :tag, tag_class: STATUS_TAG_COLOR
           end
         end
 

--- a/app/models/concerns/cm_admin/chatbot.rb
+++ b/app/models/concerns/cm_admin/chatbot.rb
@@ -24,6 +24,12 @@ module CmAdmin::Chatbot
         end
 
         tab :analytics, 'analytics', layout_type: 'cm_association_index', partial: '/chatbot/analytics'
+
+        custom_action name: 'build', route_type: 'member', verb: 'post', path: ':id/build',
+                      display_type: :button do |chatbot|
+          chatbot.build
+          chatbot
+        end
       end
 
       cm_new page_title: 'Add Chatbot', page_description: 'Enter all details to add chatbot' do

--- a/app/models/concerns/cm_admin/intent.rb
+++ b/app/models/concerns/cm_admin/intent.rb
@@ -23,6 +23,12 @@ module CmAdmin::Intent
             field :chatbot_id, label: 'Chatbot Id'
           end
         end
+
+        custom_action name: 'build', route_type: 'member', verb: 'post', path: ':id/build',
+                      display_type: :button do |intent|
+          intent.chatbot.build
+          intent
+        end
       end
 
       tab :utterances, 'utterances', associated_model: :utterances, layout_type: 'cm_association_index', display_if: -> (obj) { obj.custom? } do

--- a/app/policies/cm_admin/chatbot_policy.rb
+++ b/app/policies/cm_admin/chatbot_policy.rb
@@ -16,6 +16,10 @@ class CmAdmin::ChatbotPolicy < ApplicationPolicy
     index?
   end
 
+  def build?
+    index?
+  end
+
   class Scope < Scope
     def resolve
       if @user.super_admin?

--- a/app/policies/cm_admin/intent_policy.rb
+++ b/app/policies/cm_admin/intent_policy.rb
@@ -3,11 +3,11 @@ class CmAdmin::IntentPolicy < ApplicationPolicy
   def index?
     true
   end
-  
+
   def update?
     index?
   end
-  
+
   def destroy?
     index?
   end
@@ -20,6 +20,10 @@ class CmAdmin::IntentPolicy < ApplicationPolicy
     index?
   end
 
+  def build?
+    index?
+  end
+
   class Scope < Scope
     def resolve
       if @user.super_admin?
@@ -29,5 +33,5 @@ class CmAdmin::IntentPolicy < ApplicationPolicy
       end
     end
   end
-  
+
 end

--- a/app/services/lex_models_v2/chatbot.rb
+++ b/app/services/lex_models_v2/chatbot.rb
@@ -11,6 +11,7 @@ module LexModelsV2
 
     # Builds a bot, its intents, and its slot types into a specific locale.
     def build
+      return if @bot.building?
       resp = @models_v2_client.build_bot_locale({
         bot_id: @bot.bot_id, # required
         bot_version: 'DRAFT', # required

--- a/app/services/lex_models_v2/intent.rb
+++ b/app/services/lex_models_v2/intent.rb
@@ -93,7 +93,7 @@ module LexModelsV2
 
     # Generate an array of hash for all the responses that belongs to intent
     def generate_success_response
-      responses = @intent.responses.map(&:content)
+      responses = ::Response.where(intent: @intent).map(&:content)
 
       return nil if responses.size.zero?
 

--- a/app/services/lex_models_v2/intent.rb
+++ b/app/services/lex_models_v2/intent.rb
@@ -21,6 +21,7 @@ module LexModelsV2
       })
 
       @intent.update_column('intent_id', resp.intent_id)
+      @chatbot.update_column('status', 'not_built')
     end
 
     # Updates the settings for an intent.
@@ -60,6 +61,8 @@ module LexModelsV2
             },
           },
         })
+
+        @chatbot.update_column('status', 'not_built')
       rescue => exception
         puts exception
       end
@@ -74,6 +77,8 @@ module LexModelsV2
           bot_version: 'DRAFT', # required. Must be DRAFT
           locale_id: @chatbot.locale_id, # required
         })
+
+        @chatbot.update_column('status', 'not_built')
       rescue => exception
         puts exception
       end

--- a/db/migrate/20221207060211_add_status_to_chatbot.rb
+++ b/db/migrate/20221207060211_add_status_to_chatbot.rb
@@ -1,0 +1,6 @@
+class AddStatusToChatbot < ActiveRecord::Migration[6.1]
+  def change
+    add_column :chatbots, :status, :string, default: 'not_built', null: false
+    add_index :chatbots, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_26_102248) do
+ActiveRecord::Schema.define(version: 2022_12_07_060211) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,8 @@ ActiveRecord::Schema.define(version: 2022_11_26_102248) do
     t.string "phone_number"
     t.string "bot_alias_id"
     t.string "locale_id", default: "en_IN"
+    t.string "status", default: "not_built", null: false
+    t.index ["status"], name: "index_chatbots_on_status"
     t.index ["user_id"], name: "index_chatbots_on_user_id"
   end
 


### PR DESCRIPTION
## What?
Ability to build the chatbot from both the chatbot and intent page.

## Why?
- After making any change to intent if the chatbot is not built the response will not be returned to the end user.
- To have a streamlined and no code approach to handle the operations.

## How?
We are using the `build_bot_locale` API from AWS LexModelsV2. It is wrapped across the waiter to poll the success or failure status based on the response from AWS.

## Testing?
Tested the flow on local.