### PR TITLE
Fix: Remove unknown instance variable

### DIFF
--- a/app/models/concerns/aws_lex/intent.rb
+++ b/app/models/concerns/aws_lex/intent.rb
@@ -21,7 +21,7 @@ module AwsLex::Intent
 
   # Removes the specified intent.
   def delete_intent
-    throw(:abort) if @intent.built_in?
+    throw(:abort) if built_in?
     LexModelsV2::Intent.new(self).delete_intent if self.custom?
   end
 end


### PR DESCRIPTION
## What?
An issue with deletion of intents.

## Why?
The deletion operation for the intent was throwing the issue because the variable is `nil`