### PR TITLE
Add associated fields on index and show page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'devise'
-gem 'cm-admin', '~> 0.8.9'
+gem 'cm-admin', '~> 0.9.1'
 gem 'net-smtp'
 gem 'net-imap', require: false
 gem 'net-pop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
       actionpack (>= 3.1)
       caxlsx (>= 3.0)
     childprocess (4.1.0)
-    cm-admin (0.8.9)
+    cm-admin (0.9.1)
       caxlsx_rails
       cocoon (~> 1.2.15)
       csv-importer (~> 0.8.2)
@@ -298,7 +298,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)
-  cm-admin (~> 0.8.9)
+  cm-admin (~> 0.9.1)
   devise
   jbuilder (~> 2.7)
   listen (~> 3.3)

--- a/app/models/concerns/cm_admin/intent.rb
+++ b/app/models/concerns/cm_admin/intent.rb
@@ -19,7 +19,6 @@ module CmAdmin::Intent
           cm_show_section 'Intent Details' do
             field :name
             field :description
-            field :user_id, label: 'User Id'
             field :name, label: 'Chatbot', field_type: :association, association_name: :chatbot, association_type: :belongs_to
           end
         end

--- a/app/models/concerns/cm_admin/intent.rb
+++ b/app/models/concerns/cm_admin/intent.rb
@@ -11,7 +11,7 @@ module CmAdmin::Intent
 
         column :name
         column :description
-        column :chatbot_id
+        column :name, header: 'Chatbot', field_type: :association, association_name: :chatbot, association_type: :belongs_to
       end
 
       cm_show page_title: :name, page_description: 'Intent Details' do
@@ -20,7 +20,7 @@ module CmAdmin::Intent
             field :name
             field :description
             field :user_id, label: 'User Id'
-            field :chatbot_id, label: 'Chatbot Id'
+            field :name, label: 'Chatbot', field_type: :association, association_name: :chatbot, association_type: :belongs_to
           end
         end
 


### PR DESCRIPTION
## What?
- Update CM Admin to v0.9.1
- Replace field_type as an association for column and field.
- Remove `user_id` field from intent show page.

## Why?
- Latest version of CM Admin.
- Association field type generates a link for the associated record. It becomes easier for end-user and more accessible.

## Screenshots/Recording (optional)
Page | Before | After
--- | --- | ---
Index | <img width="1440" alt="image" src="https://user-images.githubusercontent.com/20839528/208307420-9e239a6d-7283-4a43-9c20-8304e42c1476.png"> | <img width="1440" alt="image" src="https://user-images.githubusercontent.com/20839528/208307304-9dc62e94-7c1f-4143-8a3d-09130b903902.png"> 
Show | <img width="1440" alt="image" src="https://user-images.githubusercontent.com/20839528/208307462-f5b6831f-7c5c-4d04-ba2e-7e72d9f5e734.png"> | <img width="1440" alt="image" src="https://user-images.githubusercontent.com/20839528/208307282-49fb94d2-56c2-49fa-b6bb-e222ef5e3590.png">

## Anything Else?
A new UI for the table is also tested. I noticed issues related to the z-index on the action dropdown in the table.
