### PR TITLE
Remove default title field

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,5 @@
 name: 💡 Feature request
 description: Request a feature that helps you built the platform better.
-title: ''
 labels: ['enhancement']
 assignees:
   - AdityaTiwari2102


### PR DESCRIPTION
## What?
Remove the default title field from the issue form template of feature request.

## Why?
<img width="1225" alt="image" src="https://user-images.githubusercontent.com/20839528/209565061-3d8b077f-3a1f-433b-b014-2c3079cf57cf.png">